### PR TITLE
Update CSS to match Konkat theme

### DIFF
--- a/BreadcrumbDropdowns.css
+++ b/BreadcrumbDropdowns.css
@@ -7,7 +7,7 @@
     font-size: 0.875rem;
     position: relative;
     display: list-item;
-    color: #8d939e; }
+    color: var(--pw-muted-color, #8d939e); }
   .uk-breadcrumb > li {
     display: flex; }
     .uk-breadcrumb > li::before {
@@ -15,7 +15,7 @@
     .uk-breadcrumb > li #autosave-toggle {
       margin-left: 14px; }
   .uk-breadcrumb .dropdown-toggle {
-    color: #d2d4d9 !important;
+    color: var(--pw-muted-color, #d2d4d9) !important;
     width: 21px;
     height: 21px;
     margin: 0 6px;
@@ -26,19 +26,19 @@
       left: 2px;
       bottom: 1px; }
     .uk-breadcrumb .dropdown-toggle:not(.no-dropdown):hover {
-      background-color: #f0f3f7;
-      color: #354b60 !important;
+      background-color: var(--pw-masthead-background, #f0f3f7);
+      color: var(--pw-muted-color, #354b60) !important;
       cursor: pointer; }
   .uk-breadcrumb .breadcrumb-dropdown {
     list-style: none;
-    background-color: #fff;
+    background-color: var(--pw-masthead-background, #fff);
     position: absolute;
     left: 6px;
-    top: 28px;
+    top: 26px;
     z-index: 199;
     padding: 0;
-    box-shadow: 0 1px 7px rgba(0, 0, 0, 0.175);
-    border: 1px solid #d9e1ea;
+    box-shadow: var(--pw-masthead-border-color, 0 1px 7px rgba(0, 0, 0, 0.175));
+    border: 1px solid var(--pw-masthead-border-color, #d9e1ea);
     border-bottom: none;
     display: none; }
     body.AdminThemeUikitDefault .uk-breadcrumb .breadcrumb-dropdown {
@@ -46,27 +46,28 @@
     .uk-breadcrumb .breadcrumb-dropdown.visible {
       display: block; }
     .uk-breadcrumb .breadcrumb-dropdown li.item-current .inner-item {
-      color: #e83561; }
+      color: var(--pw-main-color, #e83561); }
     .uk-breadcrumb .breadcrumb-dropdown li.add-new a {
-      background-color: #e7f6f2; }
+      background-color: var(--pw-masthead-background, #e7f6f2); }
       .uk-breadcrumb .breadcrumb-dropdown li.add-new a:hover {
-        background-color: #d6f2ea; }
+        background-color: var(--pw-masthead-menu-item-background-hover, #d6f2ea); }
     .uk-breadcrumb .breadcrumb-dropdown li.add-new i {
-      color: #3eb998;
+      color: var(--pw-text-color, #3eb998);
+      margin-right: 5px;
       margin-left: -3px; }
     .uk-breadcrumb .breadcrumb-dropdown li .inner-item {
-      color: #354b60;
+      color: var(--pw-masthead-active-color, #354b60);
       display: block;
       white-space: nowrap;
-      padding: 2px 10px 3px;
-      border-bottom: 1px solid #d9e1ea; }
+      padding: 4px 12px 5px;
+      border-bottom: 1px solid var(--pw-masthead-border-color, #d9e1ea); }
     .uk-breadcrumb .breadcrumb-dropdown li .uneditable .item-title {
       cursor: not-allowed;
       font-style: italic;
       opacity: 0.6; }
     .uk-breadcrumb .breadcrumb-dropdown li a:hover {
       text-decoration: none;
-      background-color: #f0f3f7; }
+      background-color: var(--pw-masthead-menu-item-background-hover, #f0f3f7); }
   .uk-breadcrumb .status-hidden {
     opacity: 0.6; }
   .uk-breadcrumb .status-unpublished {

--- a/BreadcrumbDropdowns.scss
+++ b/BreadcrumbDropdowns.scss
@@ -1,33 +1,33 @@
 .uk-breadcrumb { display:flex; flex-wrap:wrap;
 	.pw-panel { margin-right:-8px; } // The uneven space after the tree icon bugs me
-	li { font-size:0.875rem; position:relative; display:list-item; color:#8d939e; }
+	li { font-size:0.875rem; position:relative; display:list-item; color:var(--pw-muted-color, #8d939e); }
 	> li { display:flex;
 		&::before { content:none !important; }
 		// Page Autosave
 		#autosave-toggle { margin-left:14px; }
 	}
-	.dropdown-toggle { color:#d2d4d9 !important; width:21px; height:21px; margin:0 6px; position:relative; bottom:-1px;
+	.dropdown-toggle { color:var(--pw-muted-color, #d2d4d9) !important; width:21px; height:21px; margin:0 6px; position:relative; bottom:-1px;
 		i { position:relative; left:2px; bottom:1px; }
-		&:not(.no-dropdown):hover { background-color:#f0f3f7; color:#354b60 !important; cursor:pointer; }
+		&:not(.no-dropdown):hover { background-color:var(--pw-masthead-background, #f0f3f7); color:var(--pw-muted-color, #354b60) !important; cursor:pointer; }
 	}
-	.breadcrumb-dropdown { list-style:none; background-color:#fff; position:absolute; left:6px; top:28px; z-index:199; padding:0; box-shadow:0 1px 7px rgba(0,0,0,.175); border:1px solid #d9e1ea; border-bottom:none; display:none;
+	.breadcrumb-dropdown { list-style:none; background-color:var(--pw-masthead-background, #fff); position:absolute; left:6px; top:28px; z-index:199; padding:0; box-shadow:var(--pw-masthead-border-color, 0 1px 7px rgba(0, 0, 0, 0.175)); border:1px solid var(--pw-masthead-border-color, #d9e1ea); border-bottom:none; display:none;
 		body.AdminThemeUikitDefault & { overflow-y:auto; }
 		&.visible { display:block; }
 		li {
 			&.item-current {
-				.inner-item { color:#e83561; }
+				.inner-item { color:var(--pw-main-color, #e83561); }
 			}
 			&.add-new {
-				a { background-color:#e7f6f2;
-					&:hover { background-color:#d6f2ea; }
+				a { background-color:var(--pw-masthead-background, #e7f6f2);
+					&:hover { background-color:var(--pw-masthead-menu-item-background-hover, #d6f2ea); }
 				}
-				i { color:#3eb998; margin-left:-3px; }
+				i { color:#3eb998; margin-right: 5px; margin-left:-3px; }
 			}
-			.inner-item { color:#354b60; display:block; white-space:nowrap; padding:2px 10px 3px; border-bottom:1px solid #d9e1ea; }
+			.inner-item { color:var(--pw-masthead-active-color, #354b60); display:block; white-space:nowrap; padding:4px 12px 5px; border-bottom:1px solid var(--pw-masthead-border-color, #d9e1ea); }
 			.uneditable {
 				.item-title { cursor:not-allowed; font-style:italic; opacity:0.6; }
 			}
-			a:hover { text-decoration:none; background-color:#f0f3f7; }
+			a:hover { text-decoration:none; background-color:var(--pw-masthead-background, #f0f3f7); }
 		}
 	}
 	.status-hidden { opacity:0.6; }
@@ -36,4 +36,4 @@
 	a { white-space:nowrap; text-overflow:ellipsis; max-width:440px; overflow:hidden; }
 }
 // !important styles above are necessary due to Uikit style (shown here for reference)
-// .uk-breadcrumb > :last-child > span, .uk-breadcrumb > :last-child > a:not([href]) { color:#354b60; }
+// .uk-breadcrumb > :last-child > span, .uk-breadcrumb > :last-child > a:not([href]) { color:var(--pw-muted-color, #354b60); }


### PR DESCRIPTION
Hi @Toutouwai,

This is a small PR to use the Konkat theme’s CSS variables and falling back to current values if using the default theme.

I'm not using SCSS so I updated the CSS directly and reported the changes to the .scss file. I don’t think I missed anything, but it might be nice to double-check.

Two notes:
- I slightly increased the inner padding, but it’s a personal taste so don’t hesitate to scrap that if you prefer leaving as is
- I'm removing the box-shadow by using the `--pw-masthead-border-color` and thus invalidating the property

<img width="1019" height="677" alt="breadcrumb-dropdown-konkat-light" src="https://github.com/user-attachments/assets/1e7fc372-6b50-4afa-9871-f66606a8388a" />

<img width="1019" height="677" alt="breadcrumb-dropdown-konkat-dark" src="https://github.com/user-attachments/assets/722d86e3-4d71-4809-9f3b-1ffaf642146c" />